### PR TITLE
Fix wrong encoding of the script tag

### DIFF
--- a/lib/ActiveAdmin-Globalize3-inputs.rb
+++ b/lib/ActiveAdmin-Globalize3-inputs.rb
@@ -1,3 +1,4 @@
 require 'formtastic/globalize_inputs'
 require 'active_admin/globalize_inputs'
+require 'active_admin/globalize_attributes_table'
 require 'version'

--- a/lib/active_admin/globalize_attributes_table.rb
+++ b/lib/active_admin/globalize_attributes_table.rb
@@ -4,10 +4,12 @@ module ActiveAdmin
       builder_method :globalize_attributes_table_for
 
       def row(attr, &block)
-        I18n.available_locales.each do |locale|
+        I18n.available_locales.each_with_index do |locale, index|
           @table << tr do
-            th do
-              "#{ I18n.t("translation.#{ locale }") } #{ header_content_for(attr) }"
+            if index == 0
+              th :rowspan => I18n.available_locales.length do
+                header_content_for(attr)
+              end
             end
             td do
               I18n.with_locale locale do

--- a/lib/active_admin/globalize_attributes_table.rb
+++ b/lib/active_admin/globalize_attributes_table.rb
@@ -1,0 +1,33 @@
+module ActiveAdmin
+  module Views
+    class GlobalizeAttributesTable < ActiveAdmin::Views::AttributesTable
+      builder_method :globalize_attributes_table_for
+
+      def row(attr, &block)
+        I18n.available_locales.each do |locale|
+          @table << tr do
+            th do
+              "#{ I18n.t("translation.#{ locale }") } #{ header_content_for(attr) }"
+            end
+            td do
+              I18n.with_locale locale do
+                content_for(block || attr)
+              end
+            end
+          end
+        end
+      end
+
+      protected
+
+      def default_id_for_prefix
+        'attributes_table'
+      end
+
+      def default_class_name
+        'attributes_table'
+      end
+
+    end
+  end
+end

--- a/lib/formtastic/globalize_inputs.rb
+++ b/lib/formtastic/globalize_inputs.rb
@@ -19,7 +19,7 @@ module Formtastic
 
       linker = self.template.content_tag(:ul, linker, :class => "language-selection")
 
-      self.template.content_tag(:div, linker + fields, :class => "language-tabs-#{index}") + self.template.content_tag(:script, "$('.language-tabs-#{index}').tabs();", :type => "text/javascript")
+      self.template.content_tag(:div, linker + fields, :class => "language-tabs-#{index}") + self.template.content_tag(:script, "$('.language-tabs-#{index}').tabs();".html_safe, :type => "text/javascript")
     end
   end
 end


### PR DESCRIPTION
I wasn't able the get it running , because the content of the script tag was encoded. Marking the script as `#html_safe` fixed the issue for me.
