### PR TITLE
html_safe bug

### DIFF
--- a/lib/formtastic/globalize_inputs.rb
+++ b/lib/formtastic/globalize_inputs.rb
@@ -19,7 +19,8 @@ module Formtastic
 
       linker = self.template.content_tag(:ul, linker, :class => "language-selection")
 
-      self.template.content_tag(:div, linker + fields, :class => "language-tabs-#{index}") + self.template.content_tag(:script, "$('.language-tabs-#{index}').tabs();", :type => "text/javascript")
+      js = "$('.language-tabs-#{index}').tabs();"
+      self.template.content_tag(:div, linker + fields, :class => "language-tabs-#{index}") + self.template.content_tag(:script, js.html_safe, :type => "text/javascript")
     end
   end
 end

--- a/lib/formtastic/globalize_inputs.rb
+++ b/lib/formtastic/globalize_inputs.rb
@@ -19,7 +19,7 @@ module Formtastic
 
       linker = self.template.content_tag(:ul, linker, :class => "language-selection")
 
-      self.template.content_tag(:div, linker + fields, :class => "language-tabs-#{index}") + self.template.content_tag(:script, "$('.language-tabs-#{index}').tabs();", :type => "text/javascript")
+      self.template.content_tag(:div, linker + fields, :class => "language-tabs-#{index}") + self.template.content_tag(:script, "$('.language-tabs-#{index}').tabs();".html_safe, :type => "text/javascript")
     end
   end
 end


### PR DESCRIPTION
Added a .html_safe so that Javascript code output does not get escaped. This has been a bug. (See diff, it's just a one-line change)
